### PR TITLE
Specified exact type in example FXML

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ my/package/JustAButton.fxml:
 
 ``` xml
 <fx:root xmlns:fx="http://javafx.com/fxml/1"
-         type="javafx.scene.layout.StackPane">
+         type="my.package.JustAButton">
 
     <Button text="Press me!" onAction="#sayHello"/>
 
@@ -70,7 +70,7 @@ my/package/StillJustAButton.fxml:
 
 ``` xml
 <fx:root xmlns:fx="http://javafx.com/fxml/1"
-         type="javafx.scene.layout.StackPane">
+         type="my.package.StillJustAButton">
 
     <Button text="%someResource" onAction="#sayMessage"/>
 


### PR DESCRIPTION
Specified the exact type (i.e. my.package.JustAButton) in the
FXML in the README examples. /u/zrnkv noted that this improves
IDE support.
