### PR TITLE
Added extension point for custom builder factories

### DIFF
--- a/src/main/java/com/johnzeringue/extendsfx/CustomComponent.java
+++ b/src/main/java/com/johnzeringue/extendsfx/CustomComponent.java
@@ -15,10 +15,19 @@
  */
 package com.johnzeringue.extendsfx;
 
+import javafx.fxml.JavaFXBuilderFactory;
+import javafx.util.BuilderFactory;
+
 /**
  *
  * @author John Zeringue
  */
 public interface CustomComponent {
+
+    static BuilderFactory DEFAULT_BUILDER_FACTORY = new JavaFXBuilderFactory();
+
+    default BuilderFactory getBuilderFactory() {
+        return DEFAULT_BUILDER_FACTORY;
+    }
 
 }

--- a/src/main/java/com/johnzeringue/extendsfx/util/CustomComponentInitializer.java
+++ b/src/main/java/com/johnzeringue/extendsfx/util/CustomComponentInitializer.java
@@ -17,10 +17,11 @@ package com.johnzeringue.extendsfx.util;
 
 import com.johnzeringue.extendsfx.CustomComponent;
 import com.johnzeringue.extendsfx.exception.ExtendsFXException;
-import java.io.IOException;
-import java.net.URL;
 import javafx.fxml.FXMLLoader;
 import javafx.scene.Parent;
+
+import java.io.IOException;
+import java.net.URL;
 
 /**
  *
@@ -53,6 +54,7 @@ public class CustomComponentInitializer<T extends Parent & CustomComponent> {
     private void configureFXMLLoader() {
         fxmlLoader.setRoot(customComponent);
         fxmlLoader.setController(customComponent);
+        fxmlLoader.setBuilderFactory(customComponent.getBuilderFactory());
         fxmlLoader.setResources(resourceBundleBuilder.build());
     }
 


### PR DESCRIPTION
Added an extension point for introducing custom builder factories via
`CustomComponent#getBuilderFactory`. This should enable developers to
introduce support for dependency injection frameworks like Guice.
